### PR TITLE
Fix weatherbitch component domain and add required version

### DIFF
--- a/homeassistant/components/weatherbitch/const.py
+++ b/homeassistant/components/weatherbitch/const.py
@@ -16,7 +16,7 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SUNNY,
 )
 
-DOMAIN = "metoffice"
+DOMAIN = "weatherbitch"
 
 CONF_API_KEY = "api_key"
 

--- a/homeassistant/components/weatherbitch/manifest.json
+++ b/homeassistant/components/weatherbitch/manifest.json
@@ -1,8 +1,9 @@
 {
-  "domain": "metoffice",
-  "name": "Met Office",
+  "domain": "weatherbitch",
+  "name": "Weather Bitch",
   "codeowners": ["@MikeyProtocolSavage"],
   "config_flow": true,
   "documentation": "https://github.com/MikeyProtocolSavage/homeassistant-metoffice",
-  "iot_class": "cloud_polling"
+  "iot_class": "cloud_polling",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
The weatherbitch component has configuration issues that prevent it from loading in Home Assistant.

## Changes
- Changed domain from `metoffice` to `weatherbitch` in manifest.json and const.py
- Updated component name from "Met Office" to "Weather Bitch"
- Added required `version` field (1.0.0) to manifest.json

## Why These Changes Are Needed
1. **Domain mismatch**: The component folder is named `weatherbitch` but the domain was set to `metoffice`, causing Home Assistant to fail loading it
2. **Missing version**: Home Assistant requires a version field in manifest.json for custom components
3. These changes make the component consistent and loadable

## Testing
Applied these same changes locally and confirmed the weatherbitch component loads successfully in Home Assistant.

Fixes the component configuration to match its folder name and Home Assistant requirements.