### PR TITLE
Expand Met Office forecast fields

### DIFF
--- a/homeassistant/components/weatherbitch/CHANGELOG.md
+++ b/homeassistant/components/weatherbitch/CHANGELOG.md
@@ -70,3 +70,17 @@
 - **Data Coordinator:** Adapted to use dynamic `timesteps` and `update_interval`. Implemented and integrated the 24-hour API call counter.
 - **API Client:** Enhanced logging to provide deep insight into API interactions for debugging and monitoring.
 - **User Control:** Provides users with critical control over API usage to manage daily limits.
+## [0.1.8] - 2025-07-20
+### Added
+- All Met Office fields now mapped into Home Assistant forecast objects including dew point, min/max temperature, visibility, UV index, precipitation and snow amounts, and wind gust.
+- Raw API data preserved under `raw` in each forecast.
+### Changed
+- `MetOfficeDataUpdateCoordinator` returns `{"current": ..., "forecast": [...]}` with optional future-only filtering.
+- `MetOfficeWeather` and sensors updated to consume new data structure.
+### Fixed
+- Consistent unit conversions for pressure.
+### Findings/Deliverables Summary
+- **Forecast Schema:** Expanded to include all API fields and raw payload.
+- **Entities:** Simplified mapping via coordinator-provided data.
+- **Testing:** Added unit test validating parsing and future filtering.
+

--- a/homeassistant/components/weatherbitch/__init__.py
+++ b/homeassistant/components/weatherbitch/__init__.py
@@ -12,8 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 from .api import ApiError, MetOfficeApiClient
 from .const import (
@@ -22,6 +23,7 @@ from .const import (
     CONF_TIMESTEPS,
     CONF_UPDATE_INTERVAL,
     DOMAIN,
+    METOFFICE_WEATHER_CODE_MAP,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -131,58 +133,81 @@ class MetOfficeDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ApiError as err:
             raise UpdateFailed(f"Error fetching data: {err}") from err
 
-        # --- CRITICAL LIVE API RESPONSE PARSING (RE-ENGINEER THIS SECTION) ---
+        # --- API RESPONSE PARSING AND FORECAST CONVERSION ---
         features = data.get("features")
         if not isinstance(features, list) or not features:
-            _LOGGER.warning("API response 'features' list missing or empty: %s", features)
+            _LOGGER.warning(
+                "API response 'features' list missing or empty: %s", features
+            )
             raise UpdateFailed("Missing features in API response")
 
         properties = features[0].get("properties")
         if not isinstance(properties, dict):
-            _LOGGER.warning("API response 'properties' missing or not a dict: %s", properties)
+            _LOGGER.warning(
+                "API response 'properties' missing or not a dict: %s", properties
+            )
             raise UpdateFailed("Missing properties in API response")
 
         time_series = properties.get("timeSeries")
         if not isinstance(time_series, list) or not time_series:
-            _LOGGER.warning("API response 'timeSeries' list missing or empty: %s", time_series)
+            _LOGGER.warning(
+                "API response 'timeSeries' list missing or empty: %s", time_series
+            )
             raise UpdateFailed("Missing timeSeries in API response")
 
-        # Process each forecast item for unit conversion and key unification
-        processed_forecasts = []
-        for forecast_item in time_series:
-            processed_item = forecast_item.copy() # Work on a copy to avoid modifying original API response
+        raw_ts = time_series
+        processed: list[dict[str, Any]] = []
+        for item in raw_ts:
+            new = item.copy()
+            if (v := new.get("mslp")) is not None:
+                new["mslp_hpa"] = v / 100.0
 
-            # Convert mslp from Pascals (Pa) to hectoPascals (hPa)
-            mslp_pa = processed_item.get("mslp")
-            if mslp_pa is not None:
-                processed_item["mslp"] = mslp_pa / 100.0 # Convert to hPa
+            if "feelsLikeTemp" in new and "feelsLikeTemperature" not in new:
+                new["feelsLikeTemperature"] = new["feelsLikeTemp"]
 
-            # Unify feelsLikeTemperature key (hourly uses 'feelsLikeTemperature', three-hourly/daily use 'feelsLikeTemp')
-            if "feelsLikeTemp" in processed_item and "feelsLikeTemperature" not in processed_item:
-                processed_item["feelsLikeTemperature"] = processed_item["feelsLikeTemp"]
-                # Optionally, del processed_item["feelsLikeTemp"] if we want to strictly enforce one key
+            dt = dt_util.parse_datetime(new.get("time"))
+            new["datetime"] = dt or new.get("time")
+            processed.append(new)
 
-            processed_forecasts.append(processed_item)
+        now = dt_util.utcnow()
+        future = [
+            x
+            for x in processed
+            if isinstance(x.get("datetime"), datetime) and x["datetime"] > now
+        ]
+        forecast_list = future if future else processed
 
-        # Validate expected keys in the first processed forecast entry (current conditions)
-        expected_keys = {
-            "time",
-            "screenTemperature",
-            "feelsLikeTemperature", # Now unified
-            "probOfPrecipitation",
-            "windDirectionFrom10m",
-            "windSpeed10m",
-            "windGust10m",
-            "screenRelativeHumidity",
-            "mslp", # Now expected in hPa
-            "uvIndex",
-            "visibility",
-            "significantWeatherCode",
+        ha_forecasts: list[dict[str, Any]] = [
+            {
+                "datetime": x.get("datetime"),
+                "condition": METOFFICE_WEATHER_CODE_MAP.get(
+                    x.get("significantWeatherCode"), "unknown"
+                ),
+                "temperature": x.get("screenTemperature"),
+                "temperature_min": x.get("minScreenAirTemp"),
+                "temperature_max": x.get("maxScreenAirTemp"),
+                "feels_like": x.get("feelsLikeTemperature"),
+                "dew_point": x.get("screenDewPointTemperature"),
+                "humidity": x.get("screenRelativeHumidity"),
+                "pressure": x.get("mslp_hpa"),
+                "visibility": x.get("visibility"),
+                "uv_index": x.get("uvIndex"),
+                "wind_speed": x.get("windSpeed10m"),
+                "wind_bearing": x.get("windDirectionFrom10m"),
+                "wind_gust": x.get("windGustSpeed10m") or x.get("max10mWindGust"),
+                "precipitation": x.get("precipitationRate"),
+                "precipitation_amount": x.get("totalPrecipAmount"),
+                "snow_amount": x.get("totalSnowAmount"),
+                "precipitation_probability": x.get("probOfPrecipitation"),
+                "weather_code": x.get("significantWeatherCode"),
+                "raw": x,
+            }
+            for x in forecast_list
+        ]
+
+        current = ha_forecasts[0] if ha_forecasts else {}
+        self.data = {
+            "current": current,
+            "forecast": ha_forecasts,
         }
-        # Check against the first processed item
-        missing = [key for key in expected_keys if key not in processed_forecasts[0]]
-        if missing:
-            _LOGGER.warning("Missing expected forecast keys in first entry: %s", missing)
-
-        # Return the processed list of forecast objects, wrapped under "forecasts" key
-        return {"forecasts": processed_forecasts}
+        return self.data

--- a/homeassistant/components/weatherbitch/sensor.py
+++ b/homeassistant/components/weatherbitch/sensor.py
@@ -104,6 +104,18 @@ SENSOR_TYPES: tuple[MetOfficeSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfLength.METERS,
     ),
+    MetOfficeSensorDescription(
+        key="dew_point",
+        name="Dew Point",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    MetOfficeSensorDescription(
+        key="precipitation_amount",
+        name="Precipitation Amount",
+        native_unit_of_measurement=UnitOfLength.MILLIMETERS,
+    ),
 )
 
 
@@ -139,7 +151,7 @@ class MetOfficeSensor(MetOfficeEntity, SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return sensor value from coordinator data."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
+        current = self.coordinator.data.get("current", {})
         return current.get(self.entity_description.key)
 
 

--- a/homeassistant/components/weatherbitch/weather.py
+++ b/homeassistant/components/weatherbitch/weather.py
@@ -44,58 +44,38 @@ class MetOfficeWeather(MetOfficeEntity, WeatherEntity):
     @property
     def condition(self) -> str | None:
         """Return current weather condition."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        code = current.get("significantWeatherCode")
+        code = self.coordinator.data.get("current", {}).get("weather_code")
         return METOFFICE_WEATHER_CODE_MAP.get(code, "unknown")
 
     @property
     def temperature(self) -> float | None:
         """Return temperature."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        return current.get("screenTemperature")
+        return self.coordinator.data.get("current", {}).get("temperature")
 
     @property
     def pressure(self) -> float | None:
         """Return pressure."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        return current.get("mslp")
+        return self.coordinator.data.get("current", {}).get("pressure")
 
     @property
     def humidity(self) -> int | None:
         """Return humidity."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        return current.get("screenRelativeHumidity")
+        return self.coordinator.data.get("current", {}).get("humidity")
 
     @property
     def wind_speed(self) -> float | None:
         """Return wind speed."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        return current.get("windSpeed10m")
+        return self.coordinator.data.get("current", {}).get("wind_speed")
 
     @property
     def wind_bearing(self) -> float | None:
         """Return wind bearing."""
-        current = self.coordinator.data.get("forecasts", [{}])[0]
-        return current.get("windDirectionFrom10m")
+        return self.coordinator.data.get("current", {}).get("wind_bearing")
 
     @property
     def forecast(self) -> list[Forecast]:
         """Return the forecast in Home Assistant format."""
-        forecasts = self.coordinator.data.get("forecasts", [])
-        return [
-            {
-                "datetime": item.get("time"),
-                "condition": METOFFICE_WEATHER_CODE_MAP.get(
-                    item.get("significantWeatherCode"), "unknown"
-                ),
-                "temperature": item.get("screenTemperature"),
-                "humidity": item.get("screenRelativeHumidity"),
-                "pressure": item.get("mslp"),
-                "wind_speed": item.get("windSpeed10m"),
-                "wind_bearing": item.get("windDirectionFrom10m"),
-            }
-            for item in forecasts
-        ]
+        return self.coordinator.data.get("forecast", [])
 
 
 async def async_setup_entry(

--- a/tests/components/weatherbitch/test_coordinator.py
+++ b/tests/components/weatherbitch/test_coordinator.py
@@ -1,0 +1,106 @@
+"""Tests for the Met Office coordinator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.components.weatherbitch import MetOfficeDataUpdateCoordinator
+from homeassistant.components.weatherbitch.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_update_data_future_filter(hass: HomeAssistant) -> None:
+    """Validate future filtering and field mapping."""
+
+    api_response = {
+        "features": [
+            {
+                "properties": {
+                    "timeSeries": [
+                        {
+                            "time": "2024-01-01T09:00Z",
+                            "screenTemperature": 5,
+                            "feelsLikeTemp": 4,
+                            "screenRelativeHumidity": 80,
+                            "mslp": 100000,
+                            "uvIndex": 1,
+                            "visibility": 1000,
+                            "significantWeatherCode": 1,
+                            "windSpeed10m": 2,
+                            "windDirectionFrom10m": 180,
+                            "windGustSpeed10m": 3,
+                            "precipitationRate": 0,
+                            "probOfPrecipitation": 5,
+                            "minScreenAirTemp": 4,
+                            "maxScreenAirTemp": 6,
+                            "totalPrecipAmount": 0.1,
+                            "totalSnowAmount": 0,
+                            "screenDewPointTemperature": 4,
+                        },
+                        {
+                            "time": "2024-01-01T11:00Z",
+                            "screenTemperature": 6,
+                            "feelsLikeTemp": 5,
+                            "screenRelativeHumidity": 82,
+                            "mslp": 100500,
+                            "uvIndex": 2,
+                            "visibility": 1100,
+                            "significantWeatherCode": 2,
+                            "windSpeed10m": 3,
+                            "windDirectionFrom10m": 190,
+                            "windGustSpeed10m": 4,
+                            "precipitationRate": 0,
+                            "probOfPrecipitation": 10,
+                            "minScreenAirTemp": 5,
+                            "maxScreenAirTemp": 7,
+                            "totalPrecipAmount": 0.0,
+                            "totalSnowAmount": 0,
+                            "screenDewPointTemperature": 5,
+                        },
+                        {
+                            "time": "2024-01-01T12:00Z",
+                            "screenTemperature": 7,
+                            "feelsLikeTemp": 6,
+                            "screenRelativeHumidity": 83,
+                            "mslp": 100800,
+                            "uvIndex": 3,
+                            "visibility": 1200,
+                            "significantWeatherCode": 3,
+                            "windSpeed10m": 4,
+                            "windDirectionFrom10m": 200,
+                            "windGustSpeed10m": 5,
+                            "precipitationRate": 0,
+                            "probOfPrecipitation": 15,
+                            "minScreenAirTemp": 6,
+                            "maxScreenAirTemp": 8,
+                            "totalPrecipAmount": 0.2,
+                            "totalSnowAmount": 0,
+                            "screenDewPointTemperature": 6,
+                        },
+                    ]
+                }
+            }
+        ]
+    }
+
+    entry = MockConfigEntry(domain=DOMAIN, title="Test")
+    client = Mock()
+    client.get_point_forecast = AsyncMock(return_value=api_response)
+
+    coordinator = MetOfficeDataUpdateCoordinator(
+        hass, client, 0.0, 0.0, "hourly", timedelta(minutes=15), entry
+    )
+
+    with patch(
+        "homeassistant.util.dt.utcnow",
+        return_value=datetime(2024, 1, 1, 10, tzinfo=UTC),
+    ):
+        result = await coordinator._async_update_data()
+
+    assert len(result["forecast"]) == 2
+    assert result["current"]["temperature"] == 6
+    assert result["forecast"][0]["pressure"] == 1005.0
+    assert result["current"]["raw"]["mslp"] == 100500


### PR DESCRIPTION
## Summary
- include all API fields in the coordinator
- expose processed current/forecast data to entities
- add additional sensors
- document the changes
- add unit test for coordinator

## Testing
- `ruff check homeassistant/components/weatherbitch/__init__.py tests/components/weatherbitch/test_coordinator.py`
- `ruff format homeassistant/components/weatherbitch/__init__.py homeassistant/components/weatherbitch/sensor.py homeassistant/components/weatherbitch/weather.py tests/components/weatherbitch/test_coordinator.py`
- `pytest tests/components/weatherbitch/test_coordinator.py -q` *(fails: ModuleNotFoundError: No module named 'atomicwrites')*

------
https://chatgpt.com/codex/tasks/task_b_687cf2f76874832393323fa39721bb33